### PR TITLE
Add hn-blog-review skill

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,7 +49,7 @@ jobs:
           npm install -g @anthropic-ai/claude-code@2.1.18
           # Verify the path and version
           CLAUDE_BIN=$(which claude)
-          echo "CLAUDE_PATH=$CLAUDE_BIN" >> $GITHUB_ENV
+          echo "CLAUDE_PATH=$CLAUDE_BIN" >> "$GITHUB_ENV"
           echo "Claude binary location: $CLAUDE_BIN"
           echo "Installed Claude Code version:"
           claude --version

--- a/.github/workflows/skill-review.yml
+++ b/.github/workflows/skill-review.yml
@@ -41,9 +41,11 @@ jobs:
             | sed 's|^\(plugins/.*/skills/[^/]*/\).*|\1|' \
             | sort -u \
             | sed 's|/$||')
-          echo "dirs<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$DIRS" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          {
+            echo "dirs<<EOF"
+            echo "$DIRS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Install Claude Code v2.1.18
         run: |
@@ -53,7 +55,7 @@ jobs:
           npm install -g @anthropic-ai/claude-code@2.1.18
           # Verify the path and version
           CLAUDE_BIN=$(which claude)
-          echo "CLAUDE_PATH=$CLAUDE_BIN" >> $GITHUB_ENV
+          echo "CLAUDE_PATH=$CLAUDE_BIN" >> "$GITHUB_ENV"
           echo "Claude binary location: $CLAUDE_BIN"
           echo "Installed Claude Code version:"
           claude --version

--- a/.github/workflows/validate-frontmatter.yml
+++ b/.github/workflows/validate-frontmatter.yml
@@ -21,10 +21,12 @@ jobs:
       - name: Get changed frontmatter files
         id: changed
         run: |
-          FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only | grep -E '(agents/.*\.md|skills/.*/SKILL\.md|commands/.*\.md)$' || true)
-          echo "files<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$FILES" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          FILES=$(gh pr diff "${{ github.event.pull_request.number }}" --name-only | grep -E '(agents/.*\.md|skills/.*/SKILL\.md|commands/.*\.md)$' || true)
+          {
+            echo "files<<EOF"
+            echo "$FILES"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/plugins/lawwu-skills/skills/hn-blog-review/SKILL.md
+++ b/plugins/lawwu-skills/skills/hn-blog-review/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: hn-blog-review
+description: Generate 10-20 realistic Hacker News-style comments on a draft blog post to stress-test arguments, find weaknesses, and improve writing before publishing. Use when reviewing, critiquing, or stress-testing a blog post draft, or when asked to simulate HN feedback, comments, or reactions. Triggers on phrases like "HN comments", "Hacker News review", "stress test this post", "simulate comments", "critique this draft", "how would HN react".
+---
+
+# HN Blog Review
+
+Generate realistic Hacker News comments on a blog post draft to surface weaknesses before publishing.
+
+## Input
+
+Accept the blog post as:
+- A file path (read it)
+- A URL (fetch it)
+- Pasted text in the conversation
+
+## Process
+
+1. Read the full post carefully. Identify: thesis, key claims, evidence quality, tone, audience, technical depth, and any weak spots.
+2. Read `references/hn-archetypes.md` for commenter personas and thread patterns.
+3. Generate 10-20 comments using a realistic mix of archetypes. Follow the quality spectrum: ~30% high-signal, ~40% medium, ~30% low-signal.
+4. Include 2-3 reply threads (2-4 comments deep) where commenters disagree with each other.
+5. After the simulated thread, provide a **Post-Mortem** section.
+
+## Output Format
+
+```markdown
+## Simulated HN Thread: "[Post Title]"
+
+**[username1]** [points] points | [time] ago
+[comment text]
+
+  **[username2]** [points] points | [time] ago
+  [reply to username1]
+
+    **[username3]** [points] points | [time] ago
+    [reply to username2]
+
+**[username4]** [points] points | [time] ago
+[another top-level comment]
+
+---
+
+## Post-Mortem
+
+### Strongest Critiques
+- [Bullet list of the most valid criticisms from the thread]
+
+### Weakest Points in Your Post
+- [Specific sections or claims that would draw the most fire]
+
+### Suggested Improvements
+- [Concrete edits to preempt the strongest objections]
+
+### What Landed Well
+- [Parts that even skeptics would appreciate]
+```
+
+## Guidelines
+
+- **Usernames**: Use realistic HN-style handles (lowercase, short — e.g., `tptacek`, `dang`, `throwaway9182`, `systems_guy`, `mlresearcher`). Do not use real HN usernames.
+- **Point counts**: Vary realistically (1-250). Top comments get more; controversial ones stay low.
+- **Tone calibration**: HN skews technical, skeptical, and terse. Avoid sycophancy — HN rarely says "great post!" without a "but."
+- **Be genuinely critical**: The goal is to find real weaknesses. Pull no punches. If the post has a logical gap, exploit it. If a claim is unsupported, call it out.
+- **Match the post's domain**: AI posts get AI-savvy commenters. Finance posts get finance folks. Adjust archetype mix to the subject matter.
+- **Length variety**: Mix one-liners with multi-paragraph responses.

--- a/plugins/lawwu-skills/skills/hn-blog-review/references/hn-archetypes.md
+++ b/plugins/lawwu-skills/skills/hn-blog-review/references/hn-archetypes.md
@@ -1,0 +1,80 @@
+# HN Commenter Archetypes
+
+Use these personas to generate diverse, realistic comments. Mix and match — real threads have variety.
+
+## Archetypes
+
+### The Skeptic
+- Questions assumptions, asks for evidence
+- "I'm not convinced this actually solves X. Has anyone benchmarked this against Y?"
+- Tone: measured but doubting
+
+### The Experienced Practitioner
+- Has done this at scale, shares war stories
+- "We tried this at [BigCo] 3 years ago. The problem you'll hit is..."
+- Tone: authoritative, slightly world-weary
+
+### The Nitpicker
+- Finds the one factual error or imprecise claim
+- "Actually, that's not quite right. The RFC specifies..."
+- Tone: precise, pedantic
+
+### The Enthusiast
+- Genuinely excited, shares related resources
+- "This is great! If you liked this, you should also check out..."
+- Tone: warm, generous
+
+### The Contrarian
+- Takes the opposite position, argues the status quo is fine
+- "I don't understand why we need another X. What's wrong with Y?"
+- Tone: blunt, provocative
+
+### The Deep Diver
+- Goes deeper than the post itself
+- Asks probing technical questions the author may not have considered
+- "What happens when you hit [edge case]? The post doesn't address..."
+- Tone: curious, technical
+
+### The "Well, Actually" Expert
+- Domain expert who thinks the author is oversimplifying
+- "This glosses over the real complexity here, which is..."
+- Tone: slightly condescending but informative
+
+### The Tangent Taker
+- Latches onto one minor point and runs with it
+- Derails into a related but different discussion
+- Tone: conversational, meandering
+
+### The Show HN Critic
+- Evaluates the blog post itself (writing quality, structure)
+- "The thesis is buried in paragraph 5. Would be stronger if you led with..."
+- Tone: editorial, constructive
+
+### The First Principles Thinker
+- Reframes the whole problem from scratch
+- "The real question isn't X, it's Y. Once you see it that way..."
+- Tone: philosophical, reframing
+
+### The Cynical Veteran
+- Has seen every trend come and go
+- "We called this [old term] in 2008. Same idea, new branding."
+- Tone: jaded, dismissive
+
+### The Genuine Helper
+- Offers constructive improvements without ego
+- "Nice writeup. One thing that might strengthen this: ..."
+- Tone: friendly, helpful
+
+## Comment Quality Spectrum
+
+Real HN threads include a mix of:
+- **High-signal** (30%): Substantive critique, new information, expert context
+- **Medium-signal** (40%): Reasonable opinions, related anecdotes, clarifying questions
+- **Low-signal** (30%): Snark, tangents, "this is just X rebranded," nitpicks
+
+## Structural Patterns
+
+- **Top-level comments**: React to the post directly (thesis, claims, approach)
+- **Reply threads**: 2-4 reply chains where commenters debate each other
+- **The drive-by**: One-liner that's either devastating or vapid
+- **The essay response**: 3+ paragraphs from someone who clearly has Thoughts


### PR DESCRIPTION
## hn-blog-review

Generates 10-20 realistic Hacker News-style comments on blog post drafts to stress-test arguments and improve writing before publishing.

### What it does
- Takes a blog post (file, URL, or pasted text)
- Generates a simulated HN thread with diverse commenter archetypes (skeptic, practitioner, nitpicker, contrarian, etc.)
- Includes 2-3 realistic reply threads where commenters argue
- Follows real HN quality distribution (~30% high-signal, ~40% medium, ~30% low-signal/snark)
- Ends with a Post-Mortem: strongest critiques, weakest points, concrete improvements, what landed well

### Files
- `SKILL.md` — main instructions
- `references/hn-archetypes.md` — 12 commenter personas with tone/style guides

### Testing
Tested on two blog posts (Reflections on AI, Agentic Knowledge Work) — generated realistic, useful feedback for both.